### PR TITLE
Remove unnecessary ownership change

### DIFF
--- a/backend/provisioning-scripts/prepare-provision.sh
+++ b/backend/provisioning-scripts/prepare-provision.sh
@@ -8,6 +8,6 @@ mkdir -p /appdata/afterstyles
 
 mkdir -p /appdata/provision/${4}
 
-chown -R www-data:www-data /appdata/
+#chown -R www-data:www-data /appdata/
 
 echo "Preparation completed!"


### PR DESCRIPTION
Removes unnecessary ownership change while preparing provisions. This was introducing some latency (as it required changing ownership recursively for a folder).